### PR TITLE
Add GSL and OpenSSL to Dockerfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ jobs:
     - stage: test build
       script:
       # pull container
-      - docker pull cmbiwer/vizaly-cbench:v2
+      - docker pull cmbiwer/vizaly-cbench:v3
       # create a volume and run testing/travis/test_build.sh
-      - docker run -v "$(pwd)":/src/VizAly-CBench -it cmbiwer/vizaly-cbench:v2 /bin/bash /src/VizAly-CBench/testing/travis/test_build.sh
+      - docker run -v "$(pwd)":/src/VizAly-CBench -it cmbiwer/vizaly-cbench:v3 /bin/bash /src/VizAly-CBench/testing/travis/test_build.sh

--- a/testing/travis/Dockerfile
+++ b/testing/travis/Dockerfile
@@ -4,7 +4,7 @@ FROM centos:7
 # install packages
 RUN yum install -y epel-release && \
     yum install -y doxygen git gsl-devel hdf5-devel help2man make \
-                   rerl-CPAN perl-Thread-Queue perl-devel openssl-devel \
+                   perl-CPAN perl-Thread-Queue perl-devel openssl-devel \
                    selinux-policy sudo wget
 
 ## install gcc

--- a/testing/travis/Dockerfile
+++ b/testing/travis/Dockerfile
@@ -3,8 +3,9 @@ FROM centos:7
 
 # install packages
 RUN yum install -y epel-release && \
-    yum install -y doxygen git gsl-devel hdf5-devel help2man make perl-CPAN \
-                   perl-Thread-Queue perl-devel selinux-policy sudo wget
+    yum install -y doxygen git gsl-devel hdf5-devel help2man libssl-dev make \
+                   perl-CPAN perl-Thread-Queue perl-devel selinux-policy \
+                   sudo wget
 
 ## install gcc
 RUN yum install -y centos-release-scl && \

--- a/testing/travis/Dockerfile
+++ b/testing/travis/Dockerfile
@@ -3,9 +3,9 @@ FROM centos:7
 
 # install packages
 RUN yum install -y epel-release && \
-    yum install -y doxygen git gsl-devel hdf5-devel help2man libssl-dev make \
-                   perl-CPAN perl-Thread-Queue perl-devel selinux-policy \
-                   sudo wget
+    yum install -y doxygen git gsl-devel hdf5-devel help2man make \
+                   rerl-CPAN perl-Thread-Queue perl-devel openssl-devel \
+                   selinux-policy sudo wget
 
 ## install gcc
 RUN yum install -y centos-release-scl && \

--- a/testing/travis/Dockerfile
+++ b/testing/travis/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7
 
 # install packages
 RUN yum install -y epel-release && \
-    yum install -y doxygen git hdf5-devel help2man make perl-CPAN \
+    yum install -y doxygen git gsl-devel hdf5-devel help2man make perl-CPAN \
                    perl-Thread-Queue perl-devel selinux-policy sudo wget
 
 ## install gcc

--- a/testing/travis/README.md
+++ b/testing/travis/README.md
@@ -2,10 +2,10 @@
 
 ## Build Docker image
 
-To build docker image and tag as ``v0``, set ``${DOCKERHUB_USERNAME}`` to your DockerHub username and do
+To build docker image and tag as ``v0``, if needed set your proxy (``${http_proxy}`` and ``${https_proxy}``), set ``${DOCKERHUB_USERNAME}`` to your DockerHub username, and then do:
 ```
 TAG=v0
-docker build -t cbench .
+docker build -t cbench --build-arg http_proxy=${http_proxy} --build-arg https_proxy=${https_proxy} .
 docker tag cbench:latest ${DOCKERHUB_USERNAME}/vizaly-cbench:${TAG}
 docker push ${DOCKERHUB_USERNAME}/vizaly-cbench:${TAG}
 ```


### PR DESCRIPTION
This PR adds the packages ``gsl-devel`` and ``openssl-devel`` to ``Dockerfile`` for TravisCI.

Also updates TravisCI to use ``v3`` of the image on DockerHub.

Also includes proxy in example command for creating image.