### PR TITLE
Switch name of zfp parameter from tolerance to abs

### DIFF
--- a/inputs/HACC_all.json
+++ b/inputs/HACC_all.json
@@ -54,7 +54,7 @@
 
 		{
 			"name": "zfp",
-			"tolerance": 1E-3
+			"abs": 1E-3
 		}
 	],
 

--- a/inputs/HACC_all_write.json
+++ b/inputs/HACC_all_write.json
@@ -74,8 +74,8 @@
 
 		{
 			"name": "zfp",
-			"tolerance": 1E-3,
-			"output-prefix" : "__zfp_tol-0.001"
+			"abs": 1E-3,
+			"output-prefix" : "__zfp_abs-0.001"
 		}
 	],
 

--- a/inputs/darwin_step499.json
+++ b/inputs/darwin_step499.json
@@ -46,7 +46,7 @@
 
 		{
 			"name" : "zfp",
-			"tolerance" : 7E-3
+			"abs" : 7E-3
 		},
 
 		{

--- a/inputs/nyx_all.json
+++ b/inputs/nyx_all.json
@@ -41,7 +41,7 @@
 
 		{
 			"name": "zfp",
-			"tolerance": 1E-3
+			"abs": 1E-3
 		},
 
 		{

--- a/src/compressors/zfp/zfpCompressor.hpp
+++ b/src/compressors/zfp/zfpCompressor.hpp
@@ -72,11 +72,11 @@ inline int ZFPCompressor::compress(void *input, void *&output, std::string dataT
 			numel *= n[i];
 
     // Read in json compression parameters
-    double tolerance = 1E-3;
-    std::unordered_map<std::string, std::string>::const_iterator got = compressorParameters.find("tolerance");
+    double abs = 1E-3;
+    std::unordered_map<std::string, std::string>::const_iterator got = compressorParameters.find("abs");
     if( got != compressorParameters.end() )
-        if (compressorParameters["tolerance"] != "")
-            tolerance = strConvert::to_double( compressorParameters["tolerance"] );
+        if (compressorParameters["abs"] != "")
+            abs = strConvert::to_double( compressorParameters["abs"] );
 
     Timer cTime; 
     cTime.start();
@@ -90,8 +90,8 @@ inline int ZFPCompressor::compress(void *input, void *&output, std::string dataT
     // allocate meta data for a compressed stream
     zfp_stream* zfp = zfp_stream_open(NULL);
 
-    // set tolerance
-    zfp_stream_set_accuracy(zfp, tolerance);
+    // set absolute error tolerance
+    zfp_stream_set_accuracy(zfp, abs);
 
    	//allocate buffer for compressed data
     size_t bufsize = zfp_stream_maximum_size(zfp, field);
@@ -135,11 +135,11 @@ inline int ZFPCompressor::decompress(void *&input, void *&output, std::string da
 			numel *= n[i];
 
     // Read in json compression parameters
-	double tolerance = 1E-3;
-    std::unordered_map<std::string, std::string>::const_iterator got = compressorParameters.find("tolerance");
+	double abs = 1E-3;
+    std::unordered_map<std::string, std::string>::const_iterator got = compressorParameters.find("abs");
     if( got != compressorParameters.end() )
-        if (compressorParameters["tolerance"] != "")
-            tolerance = strConvert::to_double( compressorParameters["tolerance"] );
+        if (compressorParameters["abs"] != "")
+            abs = strConvert::to_double( compressorParameters["abs"] );
 
     Timer dTime; 
     dTime.start();
@@ -153,7 +153,7 @@ inline int ZFPCompressor::decompress(void *&input, void *&output, std::string da
 
     // allocate meta data for a compressed stream
     zfp_stream* zfp = zfp_stream_open(NULL);
-    zfp_stream_set_accuracy(zfp, tolerance);
+    zfp_stream_set_accuracy(zfp, abs);
 
     // allocate buffer for compressed data and transfer data
     size_t bufsize = zfp_stream_maximum_size(zfp, field);


### PR DESCRIPTION
The `tolerance` input is used for relative error tolerance and `abs` used for absolute error tolerance. This makes the zfp implementation in CBench match that.